### PR TITLE
Update parse_grantaward_field.ipynb for kaken5

### DIFF
--- a/parse_grantaward_field.ipynb
+++ b/parse_grantaward_field.ipynb
@@ -250,52 +250,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "細目選択数のカラムを作る。\n",
-    "\n",
-    "2013-2017の若手Bでは複数細目を選択できたので、分野別に集計する際は分野ごとに按分する必要があるため。"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df['saimokusentakusuu'] = 1\n",
-    "df"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "fukusuusaimokukadai_list = df[df['field_sequence'] == 2].awardnumber.unique()\n",
-    "len(fukusuusaimokukadai_list)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "df.loc[df['awardnumber'].isin(fukusuusaimokukadai_list), 'saimokusentakusuu'] = 2\n",
-    "df[df['saimokusentakusuu'] == 2]"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "awardnumberあたり8行になる。3565 * 8 == 28520 になっていたので特に問題なし。"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "awardnumberをインデックスに設定する"
    ]
   },
@@ -389,7 +343,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.6"
+   "version": "3.6.5"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
科研費分析ツールKAKEN5のために、grantaward_fieldテーブルに若手Bの複数細目選択課題を区別するsaimokusentakusuu（細目選択数）のカラムを追加します。

ほんとは、複数細目選択課題のみ課題番号が書いてあるテーブルを作って、KAKEN5側でSQLを書くときにOUTER JOINするほうがテーブルの設計的には美しいと思うのですが、目先のスピード重視と、正しいか間違っているかというと間違ってはいないので、こういうコードになっています。いつか時間ができたときに修正するということで、この場はこれでいきたいと思います。